### PR TITLE
Delete .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,0 @@
-{
-  "presets": [
-    [
-    "next/babel"
-    ]
-  ]
-}


### PR DESCRIPTION
Directory recently went through an upgrade and has more up-to-date next config. You can see in https://github.com/SU-SWS/adapt-directory/pull/5/files

Babel is not the first class choice any longer. Next now uses SWC. https://nextjs.org/blog/next-12-1#improved-swc-support
